### PR TITLE
💄 Add light theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,17 @@
   --font-size: 100%;
 }
 
+@media (prefers-color-scheme: light) {
+  :root {
+    /* COLORS */
+    --secondary-color: #f0f0f0;
+    --text-color: #5a5a5a;
+    --hint-color: #9f9f9f;
+    --contrast-text-color: #fff;
+    --background-color: #f5f5f5;
+  }
+}
+
 html {
   font-size: var(--font-size);
 }


### PR DESCRIPTION
fix #6

You can emulate light/dark mode in Chrome:

`More tools -> Rendering -> Emulate CSS media feature prefers color scheme`

https://stackoverflow.com/questions/57606960/how-can-i-emulate-prefers-color-scheme-media-query-in-chrome