### PR TITLE
✨ Register a new user on the Register page

### DIFF
--- a/src/app/components/Button/Button.module.css
+++ b/src/app/components/Button/Button.module.css
@@ -11,3 +11,7 @@
   font-family: var(--font-family);
   height: 3.2em;
 }
+
+.button:disabled {
+  background: var(--hint-color);
+}

--- a/src/app/components/Button/Button.tsx
+++ b/src/app/components/Button/Button.tsx
@@ -1,11 +1,13 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import styles from './Button.module.css';
 
-type ButtonProps = {
-  children: ReactNode;
-};
-function Button({ children }: ButtonProps): JSX.Element {
-  return <button className={styles.button}>{children}</button>;
+function Button(
+  props: React.DetailedHTMLProps<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    HTMLButtonElement
+  >
+): JSX.Element {
+  return <button className={styles.button} {...props} />;
 }
 
 export default Button;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,7 @@
   --background-color: #000;
   --navbar-background-color: #1a1a1a;
   --navbar-icon-color: #898989;
+  --alert-color: rgb(199, 0, 0);
 
   /* SIZES */
   --font-size: 100%;

--- a/src/app/hooks/useMutation.ts
+++ b/src/app/hooks/useMutation.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+// https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#recursive-conditional-types
+type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function useMutation<T extends (...args: any[]) => any>(
+  action: T
+): {
+  data: Awaited<ReturnType<T>> | null;
+  isLoading: boolean;
+  errorMessage: string | null;
+  mutate: (...args: Parameters<T>) => void;
+} {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [data, setData] = useState<Awaited<ReturnType<T>> | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function mutate(...args: Parameters<T>) {
+    try {
+      setIsLoading(true);
+      setData(null);
+      const result = await action(...args);
+      setData(result);
+    } catch (error) {
+      setErrorMessage(error.toString());
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return { data, isLoading, errorMessage, mutate };
+}
+
+export default useMutation;

--- a/src/app/hooks/useMutation.ts
+++ b/src/app/hooks/useMutation.ts
@@ -5,7 +5,14 @@ type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function useMutation<T extends (...args: any[]) => any>(
-  action: T
+  action: T,
+  {
+    onSuccess,
+    onError,
+  }: {
+    onSuccess?: (result: Awaited<ReturnType<T>>) => void;
+    onError?: (errorMessage: string) => void;
+  } = {}
 ): {
   data: Awaited<ReturnType<T>> | null;
   isLoading: boolean;
@@ -21,8 +28,14 @@ function useMutation<T extends (...args: any[]) => any>(
       setIsLoading(true);
       setData(null);
       const result = await action(...args);
+      if (onSuccess) {
+        onSuccess(result);
+      }
       setData(result);
     } catch (error) {
+      if (onError) {
+        onError(error.toString());
+      }
       setErrorMessage(error.toString());
     } finally {
       setIsLoading(false);

--- a/src/app/pages/Register/Register.module.css
+++ b/src/app/pages/Register/Register.module.css
@@ -29,3 +29,8 @@
   margin: auto;
   padding-bottom: 10%;
 }
+
+.registerForm__error {
+  color: var(--alert-color);
+  text-align: center;
+}

--- a/src/app/pages/Register/Register.tsx
+++ b/src/app/pages/Register/Register.tsx
@@ -5,6 +5,7 @@ import styles from './Register.module.css';
 import Button from '../../components/Button/Button';
 import BackButton from '../../components/BackButton/BackButton';
 import ProfilePictureIcon from '../../components/Icons/ProfilePictureIcon';
+import { User } from '../../../types';
 
 function RegisterForm(): JSX.Element {
   const history = useHistory();
@@ -16,7 +17,7 @@ function RegisterForm(): JSX.Element {
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const user = { email, firstName, lastName, password };
+    const user: User = { email, firstName, lastName, password };
     await fetch('/api/users', {
       method: 'POST',
       headers: {

--- a/src/app/pages/Register/Register.tsx
+++ b/src/app/pages/Register/Register.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import LabeledInput from '../../components/LabeledInput/LabeledInput';
 import styles from './Register.module.css';
@@ -16,16 +16,14 @@ function RegisterForm(): JSX.Element {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const { data: user, mutate, isLoading, errorMessage } = useMutation(postUser);
+  const { mutate, isLoading, errorMessage } = useMutation(postUser, {
+    onSuccess: () => {
+      history.push('/');
+    },
+  });
   const [validationErrorMessage, setValidationErrorMessage] = useState<
     string | null
   >(null);
-
-  useEffect(() => {
-    if (user) {
-      history.push('/');
-    }
-  }, [user]);
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/src/app/pages/Register/Register.tsx
+++ b/src/app/pages/Register/Register.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import LabeledInput from '../../components/LabeledInput/LabeledInput';
 import styles from './Register.module.css';
 import Button from '../../components/Button/Button';
@@ -6,15 +7,24 @@ import BackButton from '../../components/BackButton/BackButton';
 import ProfilePictureIcon from '../../components/Icons/ProfilePictureIcon';
 
 function RegisterForm(): JSX.Element {
+  const history = useHistory();
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    alert(`${firstName} submitted`);
+    const user = { email, firstName, lastName, password };
+    await fetch('/api/users', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(user),
+    });
+    history.push('/');
   }
 
   return (

--- a/src/app/utils/api.ts
+++ b/src/app/utils/api.ts
@@ -1,0 +1,17 @@
+import { User } from '../../types';
+
+export async function postUser(user: User): Promise<User> {
+  const response = await fetch('/api/users', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(user),
+  });
+  if (!response.ok) {
+    const errorMessage = await response.text();
+    throw errorMessage;
+  }
+  const result: User = await response.json();
+  return result;
+}


### PR DESCRIPTION
Fix #8 
Similar to the `useFetch` custom hook, `useMutation` is used to send data.
It's fully typed (the TS part is over 9000, not easy to understand), but the logic/JS is worth to investigate 🕵️‍♀️.
The implementation is inspired by https://react-query.tanstack.com/reference/useMutation

You can test the register page on https://photoplay900-registerus-qfarxu.herokuapp.com/register.
The submit button is disabled if you submit the form to prevent multiple requests (throttle your connection to see it).
Error messages are displayed next to the button (email already exists, passwords didn't match).
If the registration succeeded, the user is redirected to the home page.

Adding a profile picture is not implemented yet.