### PR TITLE
🚑 Forward client routing in production

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { connectMongoClient } from './server/db';
 import router from './server/routes';
 import { createUsersCollection } from './server/users';
 import cookieParser from 'cookie-parser';
+import path from 'path';
 
 const { PORT } = process.env;
 
@@ -23,6 +24,11 @@ app.use('/storybook', express.static('dist/storybook'));
 
 // Serve app production bundle
 app.use(express.static('dist/app'));
+
+// Handle client routing, return all requests to the app
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'app/index.html'));
+});
 
 /**
  * Error handling for all routes.


### PR DESCRIPTION
On production (Heroku deployment or `npm start`), it's not possible to directly go to routes like `/register`.
This pull request fixes this issue and forwards all routes to the client.